### PR TITLE
refactor (#105) :: 리소스별 권한 정책 리팩토링 및 requestMatchers 구조 정리

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/global/config/SecurityConfig.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/global/config/SecurityConfig.java
@@ -44,39 +44,54 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/auth/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/user/submission").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.GET,"/user/**").permitAll()
+                .authorizeHttpRequests(auth -> auth
+
+                        // auth
+                        .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/auth/reissue").permitAll()
+
+                        // user
+                        .requestMatchers(HttpMethod.GET, "/user/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/user/submission").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.PATCH, "/user/decide/**").hasAnyRole(CLUB_MEMBER, CLUB_LEADER, STUDENT)
-                        .requestMatchers(HttpMethod.PATCH,"/user/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers("/admin/**").hasAnyRole(ADMIN)
-                        .requestMatchers("/club/member/apply").hasAnyRole(CLUB_MEMBER, CLUB_LEADER)
-                        .requestMatchers(HttpMethod.GET, "/club/submission/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.PATCH, "/user/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.POST, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.GET, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.DELETE, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+
+                        // admin
+                        .requestMatchers("/admin/**").hasRole(ADMIN)
+
+                        // club
                         .requestMatchers(HttpMethod.GET, "/club/**").permitAll()
-                        .requestMatchers("/club/create/apply").hasAnyRole(STUDENT, ADMIN, TEACHER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.POST, "/club/member/apply").hasAnyRole(CLUB_MEMBER, CLUB_LEADER)
+                        .requestMatchers(HttpMethod.GET, "/club/submission/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.POST, "/club/create/apply").hasAnyRole(STUDENT, ADMIN, TEACHER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.POST, "/club/dissolution").hasRole(CLUB_LEADER)
                         .requestMatchers(HttpMethod.PATCH, "/club/pass/**").hasRole(CLUB_LEADER)
-                        .requestMatchers(HttpMethod.PATCH,"/club/**").hasAnyRole(CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.POST,"/application-form/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.GET,"/application-form/**").permitAll()
-                        .requestMatchers(HttpMethod.PATCH,"/application-form/**").hasAnyRole(CLUB_MEMBER, CLUB_LEADER)
-                        .requestMatchers(HttpMethod.DELETE,"/application-form/**").hasAnyRole(CLUB_MEMBER, CLUB_LEADER)
+                        .requestMatchers(HttpMethod.PATCH, "/club/**").hasAnyRole(CLUB_MEMBER)
                         .requestMatchers(HttpMethod.DELETE, "/club/member/**").hasRole(CLUB_LEADER)
                         .requestMatchers(HttpMethod.GET, "/club/alarm").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.POST, "/announcement").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
+
+                        // announcement
                         .requestMatchers(HttpMethod.GET, "/announcement/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/announcement").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.PATCH, "/announcement/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.DELETE, "/announcement/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.POST,"/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.GET,"/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.DELETE,"/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+
+                        // schedule
                         .requestMatchers(HttpMethod.POST, "/schedule/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.PATCH, "/schedule/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.GET, "/schedule/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.POST,"/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.GET,"/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
-                        .requestMatchers(HttpMethod.DELETE,"/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+
+                        // application
+                        .requestMatchers(HttpMethod.POST, "/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.GET, "/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.DELETE, "/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+
+                        // application-form
+                        .requestMatchers(HttpMethod.GET, "/application-form/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .with(new SecurityFilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())


### PR DESCRIPTION
## #️⃣연관된 이슈

- #105

## 📝작업 내용

> SecurityConfig의 인가(authorization) 설정을 전반적으로 리팩토링하여 도메인별로 명확히 구분하고, URL 패턴에 따른 권한 적용 정책을 
구조화하고, 이를 통해 코드 가독성, 유지보수성, 정책 일관성을 개선하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안 개선사항

* **Bug Fixes**
  * 역할 기반 접근 제어를 세분화하여 API 엔드포인트별 권한 규칙을 강화했습니다.
  * 인증, 사용자, 관리자, 클럽, 공지사항, 일정, 신청서 경로에 대한 접근 권한이 조정되었습니다.
  * 사용자 역할에 따른 기능 접근성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->