### PR TITLE
fix (#107) :: 전체적인 권한 설정에서 구체적인 경로가 먼저 매칭되도록 정렬

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/global/config/SecurityConfig.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/global/config/SecurityConfig.java
@@ -52,19 +52,18 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/auth/reissue").permitAll()
 
                         // user
-                        .requestMatchers(HttpMethod.GET, "/user/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/user/submission").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.PATCH, "/user/decide/**").hasAnyRole(CLUB_MEMBER, CLUB_LEADER, STUDENT)
                         .requestMatchers(HttpMethod.PATCH, "/user/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.POST, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.GET, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.DELETE, "/user/application/**").hasAnyRole(STUDENT, CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.GET, "/user/**").permitAll()
 
                         // admin
                         .requestMatchers("/admin/**").hasRole(ADMIN)
 
                         // club
-                        .requestMatchers(HttpMethod.GET, "/club/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/club/member/apply").hasAnyRole(CLUB_MEMBER, CLUB_LEADER)
                         .requestMatchers(HttpMethod.GET, "/club/submission/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.POST, "/club/create/apply").hasAnyRole(STUDENT, ADMIN, TEACHER, CLUB_MEMBER)
@@ -73,12 +72,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/club/**").hasAnyRole(CLUB_MEMBER)
                         .requestMatchers(HttpMethod.DELETE, "/club/member/**").hasRole(CLUB_LEADER)
                         .requestMatchers(HttpMethod.GET, "/club/alarm").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.GET, "/club/**").permitAll()
 
                         // announcement
-                        .requestMatchers(HttpMethod.GET, "/announcement/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/announcement").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.PATCH, "/announcement/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
                         .requestMatchers(HttpMethod.DELETE, "/announcement/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)
+                        .requestMatchers(HttpMethod.GET, "/announcement/**").permitAll()
 
                         // schedule
                         .requestMatchers(HttpMethod.POST, "/schedule/**").hasAnyRole(CLUB_LEADER, CLUB_MEMBER)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #107

## 📝작업 내용

> 보안 설정 내에서 포괄적인 URL 패턴이 구체적인 패턴보다 먼저 매칭되는 문제가 있어,
> 일부 엔드포인트의 권한 검증이 의도대로 적용되지 않는 상황을 확인했습니다.
> 이를 해결하기 위해 requestMatchers의 선언 순서를 재정렬하여 우선순위를 명확히 보장하도록 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 관리**
  * 보안 설정 규칙의 순서를 조정하여 시스템 안정성을 개선했습니다. 사용자 권한 및 기능에는 변경사항이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->