### PR TITLE
 refactor (#125) :: QueryAnnouncementDetailResponse에 phoneNumber 필드 추가

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/announcement/presentation/dto/response/QueryAnnouncementDetailResponse.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/announcement/presentation/dto/response/QueryAnnouncementDetailResponse.java
@@ -12,6 +12,7 @@ import java.util.List;
 public record QueryAnnouncementDetailResponse(
         String title,
         List<Major> major,
+        String phoneNumber,
         LocalDate deadline,
         String introduction,
         String talentDescription,
@@ -22,6 +23,7 @@ public record QueryAnnouncementDetailResponse(
         return QueryAnnouncementDetailResponse.builder()
                 .title(announcement.getTitle())
                 .major(announcement.getAnnouncementMajors().stream().map(AnnouncementMajor::getMajor).toList())
+                .phoneNumber(announcement.getPhoneNumber())
                 .deadline(announcement.getDeadline())
                 .introduction(announcement.getIntroduction())
                 .talentDescription(announcement.getTalentDescription())


### PR DESCRIPTION
## #️⃣연관된 이슈

- #125

## 📝작업 내용

> 공고 상세 조회 시 response dto에 누락된 `phoneNumber(대표자 연락처)`를 추가하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공지사항 상세 정보에 전화번호 필드가 추가되었습니다. 사용자는 이제 공지사항 상세 페이지에서 전화번호를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->