### PR TITLE
CHORE[#164] :: PR 시 배포 방지를 위한 CI/CD 파이프라인 분리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           context: .
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Login to Docker Hub
         if: github.event_name == 'push'


### PR DESCRIPTION
… steps

## #️⃣연관된 이슈

- #164

## 📝작업 내용

기존 CI/CD 파이프라인에서는 `pull_request` 이벤트 발생 시에도 Docker 이미지 빌드, 푸시, 그리고 EC2 배포까지 모두 수행되어
아직 검증되지 않은 코드가 운영 환경에 배포되는 문제가 발생할 수 있었습니다.

이를 개선하기 위해 이벤트 유형에 따라 작업을 분리했습니다.

### 변경 사항

* `pull_request` 이벤트

  * Docker 이미지 **빌드만 수행**
  * 이미지 푸시 및 EC2 배포는 수행하지 않음 (CI 전용)

* `push` 이벤트 (`main`, `develop` 브랜치)

  * Docker Hub 로그인
  * Docker 이미지 빌드 및 푸시
  * EC2 서버에 배포 수행 (CD 전용)

### 기대 효과

* PR 단계에서는 코드 품질 검증에만 집중
* Merge 이후에만 실제 배포가 이루어져 미완성 코드의 운영 반영을 방지
* CI / CD 역할이 명확히 분리된 안정적인 배포 파이프라인 구성


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Pull Request 빌드 검증 단계 추가 - 병합 전 코드 품질 확인

* **Chores**
  * CI/CD 파이프라인 최적화 - Docker 로그인 및 배포 단계를 푸시 이벤트로만 제한
  * Pull Request와 푸시 이벤트에 대한 빌드 프로세스 분리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->