### PR TITLE
FEAT[#165] :: CI/CD Discord 알림에 PR 빌드 / 배포 상태 구분 기능 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,8 +83,8 @@ jobs:
                 "title": $title,
                 "color": $color,
                 "fields": [
-                  { "name": "Repository", "value": $repo, "inline": true },
-                  { "name": "Branch", "value": $branch, "inline": true },
+                  { "name": "Repository", "value": $repo },
+                  { "name": "Branch", "value": $branch },
                   { "name": "Commit", "value": $commit },
                   { "name": "Triggered By", "value": $actor }
                 ],


### PR DESCRIPTION
## #️⃣연관된 이슈

- #166

## 📝작업 내용
- GitHub Actions 이벤트 타입(`github.event_name`)에 따라 Discord 알림 메시지 분기 처리
  - `pull_request`
    - 성공: 🚀 PR 빌드 성공
    - 실패: 🚨 PR 빌드 실패
  - `push` (main / develop merge 후 배포)
    - 성공: ✅ 배포 성공
    - 실패: ❌ 배포 실패
- 모든 알림에 공통 메타 정보 추가
  - Repository
  - Branch
  - Commit SHA
  - Trigger User
- `if: always()` 조건을 사용하여 성공/실패 여부와 무관하게 알림이 전송되도록 구성

### 기대 효과
- PR 검증 단계와 실제 운영 배포 단계를 Discord 알림에서 명확히 구분 가능
- 장애 발생 시 “빌드 실패”인지 “배포 실패”인지 즉시 파악 가능
- 팀원들이 알림만 보고도 현재 파이프라인 상태를 직관적으로 이해 가능

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 배포 단계가 알림 전송 단계를 대체하여, 배포 과정 대신 항상 Discord로 결과를 통지합니다.
  * PR/배포 타입과 성공·실패에 따라 제목과 색상을 구분해 전송하며, 저장소·브랜치·커밋·실행자·런 URL 등 관련 정보가 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->