### PR TITLE
[CI] :: Docker Hub에서 GHCR로 도커 이미지 레지스트리 마이그레이션

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ permissions:
   deployments: write
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/daedongyeojido
+  IMAGE_NAME: ghcr.io/team-jeong-ho-kim/daedongyeojido
 
 jobs:
   ci:
@@ -127,7 +127,7 @@ jobs:
 
       - name: Login to GHCR
         uses: docker/login-action@v3
-        with:https://github.com/Team-jeong-ho-kim/Daedongyeojido_BE_v4.0
+        with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #233

## 📝작업 내용

> 이 PR은 기존 CI/CD 파이프라인에서 사용 중이던 외부 컨테이너 저장소(Docker Hub)를 깃허브 내장 서비스인 **GHCR(GitHub Container Registry)**로 이전하는 작업을 포함합니다.

> 외부 서비스용 인증 정보(Secrets)를 별도로 관리할 필요 없이 깃허브에서 제공하는 기본 토큰(`GITHUB_TOKEN`)을 사용하여 배포 프로세스를 간소화하고 보안을 강화했습니다. 또한, 소스 코드와 컴파일된 도커 이미지를 깃허브 레포지토리 한 곳에서 통합 관리(Packages UI 연동)할 수 있도록 개선했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너 레지스트리를 GitHub Container Registry(GHCR)로 이전했습니다.
  * 빌드/푸시 및 배포 워크플로우의 인증 및 자격증명 구성을 GHCR 기반으로 변경했습니다.
  * GitHub Actions 권한 설정을 상위 레벨로 정리해 간소화했습니다.
  * EC2 배포 단계에서 GHCR 인증을 추가해 이미지 풀링을 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->