### PR TITLE
fix (#234) :: 동아리 신청 거절시 동아리 삭제

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/DecideClubCreationService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/DecideClubCreationService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.jeonghokim.daedongyeojido.domain.admin.presentation.dto.request.DecideClubCreationRequest;
 import team.jeonghokim.daedongyeojido.domain.alarm.domain.enums.AlarmType;
 import team.jeonghokim.daedongyeojido.domain.club.domain.Club;
+import team.jeonghokim.daedongyeojido.domain.club.domain.repository.ClubRepository;
 import team.jeonghokim.daedongyeojido.domain.user.domain.User;
 import team.jeonghokim.daedongyeojido.domain.user.domain.repository.UserRepository;
 import team.jeonghokim.daedongyeojido.domain.user.exception.UserNotFoundException;
@@ -21,6 +22,7 @@ public class DecideClubCreationService {
     private final ClubFacade clubFacade;
     private final ApplicationEventPublisher eventPublisher;
     private final AlarmEventFactory alarmEventFactory;
+    private final ClubRepository clubRepository;
 
     @Transactional
     public void execute(Long clubId, DecideClubCreationRequest request) {
@@ -40,6 +42,8 @@ public class DecideClubCreationService {
         } else {
 
             rejectClub(club, user);
+
+            clubRepository.delete(club);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #234 

## 📝작업 내용

> 기존에는 boolean으로 되어있는 isOpen을 enum으로 분리해서 open, close, reject 3가지 상태를 가지고 있도록 하려고 했는데 
개설 신청이 거절된 동아리가 상태가 변경된 상태로 db에 남아 있어야 하는 이유를 찾지 못해서
동아리 개설 요청이 반려되었을 경우 그냥 동아리 자체를 삭제하도록 변경하였습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 클럽 생성 거절 시 해당 클럽 데이터가 시스템에서 완전히 제거되어 데이터 정합성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->