### PR TITLE
FEAT[#261] :: major ENUM에 ETC 값 추가 및 정의 통일 (Flyway)

### DIFF
--- a/src/main/resources/db/migration/V3__add_etc_to_major_enum.sql
+++ b/src/main/resources/db/migration/V3__add_etc_to_major_enum.sql
@@ -1,0 +1,35 @@
+-- tbl_announcement_major
+ALTER TABLE tbl_announcement_major
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+) NOT NULL;
+
+-- tbl_application_major
+ALTER TABLE tbl_application_major
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+) NOT NULL;
+
+-- tbl_club_creation_application_major
+ALTER TABLE tbl_club_creation_application_major
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+) NOT NULL;
+
+-- tbl_club_major
+ALTER TABLE tbl_club_major
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+) NOT NULL;
+
+-- tbl_submission
+ALTER TABLE tbl_submission
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+) NOT NULL;
+
+-- tbl_user_major (여긴 기존에 ETC 있었지만 통일 차원에서 명시 추천)
+ALTER TABLE tbl_user_major
+MODIFY COLUMN major ENUM(
+    'BE','FE','DEVOPS','IOS','ANDROID','FLUTTER','EMBEDDED','AI','DESIGN','SECURITY','GAME','ETC'
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #261

## 📝작업 내용

# 🔧 작업 내용
▪ 모든 major ENUM 컬럼에 ETC 값 추가  
▪ ENUM 정의를 전체 재작성(MODIFY COLUMN)하여 스키마 일관성 확보  
▪ Flyway 마이그레이션 스크립트 추가  

# 🗂️ 변경 대상 테이블
▪ tbl_announcement_major  
▪ tbl_application_major  
▪ tbl_club_creation_application_major  
▪ tbl_club_major  
▪ tbl_submission  
▪ tbl_user_major  


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 전공 선택 옵션에 "ETC(기타)" 항목이 추가되었습니다. 이제 기존 전공 외에 기타 선택지를 통해 더 유연한 전공 관리가 가능합니다.

* **개선사항**
  * 시스템 전반의 전공 데이터 정합성 및 무결성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->