### PR TITLE
Hotfix/#266 application cancel prevent

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/application/exception/CannotCancelApplicationWithInterviewScheduleException.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/application/exception/CannotCancelApplicationWithInterviewScheduleException.java
@@ -1,0 +1,13 @@
+package team.jeonghokim.daedongyeojido.domain.application.exception;
+
+import team.jeonghokim.daedongyeojido.global.error.exception.DaedongException;
+import team.jeonghokim.daedongyeojido.global.error.exception.ErrorCode;
+
+public class CannotCancelApplicationWithInterviewScheduleException extends DaedongException {
+
+    public static final DaedongException EXCEPTION = new CannotCancelApplicationWithInterviewScheduleException();
+
+    private CannotCancelApplicationWithInterviewScheduleException() {
+        super(ErrorCode.CANNOT_CANCEL_APPLICATION_WITH_INTERVIEW_SCHEDULE);
+    }
+}

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CancelApplicationService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CancelApplicationService.java
@@ -7,9 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import team.jeonghokim.daedongyeojido.domain.alarm.domain.enums.AlarmType;
 import team.jeonghokim.daedongyeojido.domain.application.exception.ApplicationAccessDeniedException;
 import team.jeonghokim.daedongyeojido.domain.application.exception.ApplicationNotSubmittedException;
+import team.jeonghokim.daedongyeojido.domain.application.exception.CannotCancelApplicationWithInterviewScheduleException;
 import team.jeonghokim.daedongyeojido.domain.club.domain.Club;
 import team.jeonghokim.daedongyeojido.domain.schedule.domain.repository.ScheduleRepository;
-import team.jeonghokim.daedongyeojido.domain.schedule.exception.AlreadyInterviewScheduleExistsException;
 import team.jeonghokim.daedongyeojido.domain.submission.domain.Submission;
 import team.jeonghokim.daedongyeojido.domain.submission.facade.SubmissionFacade;
 import team.jeonghokim.daedongyeojido.domain.user.domain.User;
@@ -41,7 +41,7 @@ public class CancelApplicationService {
         }
 
         if (scheduleRepository.existsByApplicantAndClub(submission.getUser(), submission.getApplicationForm().getClub())) {
-            throw AlreadyInterviewScheduleExistsException.EXCEPTION;
+            throw CannotCancelApplicationWithInterviewScheduleException.EXCEPTION;
         }
 
         submission.cancel();

--- a/src/main/java/team/jeonghokim/daedongyeojido/global/error/exception/ErrorCode.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/global/error/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     APPLICATION_ACCESS_DENIED(403, "지원서 관련 권한이 없습니다."),
     CANNOT_MODIFY_APPLICATION(400, "지원서를 수정할 수 없습니다."),
     CANNOT_DELETE_APPLICATION(400, "지원서를 삭제할 수 없습니다."),
+    CANNOT_CANCEL_APPLICATION_WITH_INTERVIEW_SCHEDULE(409, "면접 일정이 생성되어 지원 취소를 할 수 없습니다."),
     APPLICATION_NOT_SUBMITTED(400, "제출하지 않은 지원서입니다."),
     APPLICATION_NOT_ACCEPTED(400, "합격되지 않은 지원서입니다."),
     ALREADY_APPLICATION_EXIST(409, "해당 동아리의 지원서가 이미 존재합니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #266 

## 📝작업 내용

> 면접 일정 생성 시 지원 취소 불가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 면접 일정이 생성된 지원은 취소할 수 없도록 제한합니다. 이미 예정된 면접이 있는 경우 지원 취소 시도 시 오류 메시지를 표시하여 실수로 인한 취소를 방지하고 일정 관리의 일관성을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->