### PR TITLE
Fix/#284 application duplicate check by form

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepository.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface SubmissionRepository extends JpaRepository<Submission, Long>, SubmissionRepositoryCustom {
 
+    boolean existsByUserIdAndApplicationFormId(Long userId, Long applicationFormId);
+
     Optional<Submission> findTopByUserIdAndApplicationFormClubIdOrderByIdDesc(Long userId, Long clubId);
 }

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepository.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepository.java
@@ -1,6 +1,7 @@
 package team.jeonghokim.daedongyeojido.domain.submission.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.jeonghokim.daedongyeojido.domain.application.domain.enums.ApplicationStatus;
 import team.jeonghokim.daedongyeojido.domain.submission.domain.Submission;
 
 import java.util.Optional;
@@ -10,4 +11,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long>, S
     boolean existsByUserIdAndApplicationFormId(Long userId, Long applicationFormId);
 
     Optional<Submission> findTopByUserIdAndApplicationFormClubIdOrderByIdDesc(Long userId, Long clubId);
+
+    Optional<Submission> findTopByUserIdAndApplicationFormClubIdAndUserApplicationStatusOrderByIdDesc(
+            Long userId,
+            Long clubId,
+            ApplicationStatus userApplicationStatus
+    );
 }

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepositoryCustom.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepositoryCustom.java
@@ -16,7 +16,5 @@ public interface SubmissionRepositoryCustom {
 
     List<SubmissionListResponse> findAllSubmissionByUserId(Long userId);
 
-    Optional<Submission> findByUserIdAndClubId(Long userId, Long clubId);
-
     Optional<Submission> findSubmissionById(Long submissionId);
 }

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepositoryCustomImpl.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/submission/domain/repository/SubmissionRepositoryCustomImpl.java
@@ -90,22 +90,6 @@ public class SubmissionRepositoryCustomImpl implements SubmissionRepositoryCusto
     }
 
     @Override
-    public Optional<Submission> findByUserIdAndClubId(Long userId, Long clubId) {
-        return Optional.ofNullable(
-                jpaQueryFactory
-                        .selectFrom(submission)
-                        .join(submission.user, user).fetchJoin()
-                        .join(submission.applicationForm, applicationForm).fetchJoin()
-                        .join(applicationForm.club, club).fetchJoin()
-                        .where(
-                                submission.user.id.eq(userId),
-                                applicationForm.club.id.eq(clubId)
-                        )
-                        .fetchOne()
-        );
-    }
-
-    @Override
     public Optional<Submission> findSubmissionById(Long submissionId) {
         return Optional.ofNullable(
                 jpaQueryFactory

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
@@ -32,7 +32,7 @@ public class CreateApplicationService {
 
         ApplicationForm applicationForm = applicationFormFacade.getApplicationById(applicationFormId);
 
-        if (submissionRepository.findByUserIdAndClubId(user.getId(), applicationForm.getClub().getId()).isPresent()) {
+        if (submissionRepository.existsByUserIdAndApplicationFormId(user.getId(), applicationForm.getId())) {
             throw AlreadyApplicationExistException.EXCEPTION;
         }
 

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
@@ -1,6 +1,7 @@
 package team.jeonghokim.daedongyeojido.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class CreateApplicationService {
+    private static final String SUBMISSION_UNIQUE_CONSTRAINT = "unique_idx_submission_account_form";
+
     private final SubmissionRepository submissionRepository;
     private final UserFacade userFacade;
     private final ApplicationFormFacade applicationFormFacade;
@@ -49,8 +52,33 @@ public class CreateApplicationService {
                             .userApplicationStatus(ApplicationStatus.WRITING)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            throw AlreadyApplicationExistException.EXCEPTION;
+            if (isSubmissionUniqueConstraintViolation(e)) {
+                throw AlreadyApplicationExistException.EXCEPTION;
+            }
+            throw e;
         }
+    }
+
+    private boolean isSubmissionUniqueConstraintViolation(DataIntegrityViolationException e) {
+        Throwable cause = e;
+
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException constraintViolationException) {
+                String constraintName = constraintViolationException.getConstraintName();
+                if (constraintName != null && constraintName.contains(SUBMISSION_UNIQUE_CONSTRAINT)) {
+                    return true;
+                }
+            }
+
+            String message = cause.getMessage();
+            if (message != null && message.contains(SUBMISSION_UNIQUE_CONSTRAINT)) {
+                return true;
+            }
+
+            cause = cause.getCause();
+        }
+
+        return false;
     }
 
     private List<ApplicationAnswer> createAnswer(SubmissionRequest request, ApplicationForm applicationForm) {

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/CreateApplicationService.java
@@ -1,6 +1,7 @@
 package team.jeonghokim.daedongyeojido.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.jeonghokim.daedongyeojido.domain.application.domain.ApplicationAnswer;
@@ -36,16 +37,20 @@ public class CreateApplicationService {
             throw AlreadyApplicationExistException.EXCEPTION;
         }
 
-        submissionRepository.save(Submission.builder()
-                        .userName(request.getUserName())
-                        .classNumber(request.getClassNumber())
-                        .introduction(request.getIntroduction())
-                        .answers(createAnswer(request, applicationForm))
-                        .major(request.getMajor())
-                        .user(user)
-                        .applicationForm(applicationForm)
-                        .userApplicationStatus(ApplicationStatus.WRITING)
-                .build());
+        try {
+            submissionRepository.saveAndFlush(Submission.builder()
+                            .userName(request.getUserName())
+                            .classNumber(request.getClassNumber())
+                            .introduction(request.getIntroduction())
+                            .answers(createAnswer(request, applicationForm))
+                            .major(request.getMajor())
+                            .user(user)
+                            .applicationForm(applicationForm)
+                            .userApplicationStatus(ApplicationStatus.WRITING)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw AlreadyApplicationExistException.EXCEPTION;
+        }
     }
 
     private List<ApplicationAnswer> createAnswer(SubmissionRequest request, ApplicationForm applicationForm) {

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/DecideClubService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/user/service/DecideClubService.java
@@ -40,7 +40,12 @@ public class DecideClubService {
 
         alarm.executed();
 
-        Submission submission = submissionRepository.findByUserIdAndClubId(applicant.getId(), alarm.getClub().getId())
+        Submission submission = submissionRepository
+                .findTopByUserIdAndApplicationFormClubIdAndUserApplicationStatusOrderByIdDesc(
+                        applicant.getId(),
+                        alarm.getClub().getId(),
+                        ApplicationStatus.ACCEPTED
+                )
                 .orElseThrow(() -> SubmissionNotFoundException.EXCEPTION);
 
         validate(applicant, submission, alarm);

--- a/src/main/java/team/jeonghokim/daedongyeojido/global/error/exception/ErrorCode.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/global/error/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     CANNOT_CANCEL_APPLICATION_WITH_INTERVIEW_SCHEDULE(409, "면접 일정이 생성되어 지원 취소를 할 수 없습니다."),
     APPLICATION_NOT_SUBMITTED(400, "제출하지 않은 지원서입니다."),
     APPLICATION_NOT_ACCEPTED(400, "합격되지 않은 지원서입니다."),
-    ALREADY_APPLICATION_EXIST(409, "해당 동아리의 지원서가 이미 존재합니다."),
+    ALREADY_APPLICATION_EXIST(409, "해당 공고의 지원서가 이미 존재합니다."),
 
     // club
     ALREADY_EXISTS_CLUB(409, "해당 동아리가 이미 존재합니다."),

--- a/src/main/resources/db/migration/V4__add_submission_unique_constraint_per_form.sql
+++ b/src/main/resources/db/migration/V4__add_submission_unique_constraint_per_form.sql
@@ -1,3 +1,36 @@
+CREATE TEMPORARY TABLE `tmp_submission_ranked` AS
+SELECT
+    s.id,
+    ROW_NUMBER() OVER (
+        PARTITION BY s.account_id, s.application_form_id
+        ORDER BY
+            CASE s.user_application_status
+                WHEN 'ACCEPTED' THEN 4
+                WHEN 'REJECTED' THEN 3
+                WHEN 'SUBMITTED' THEN 2
+                WHEN 'WRITING' THEN 1
+                ELSE 0
+            END DESC,
+            s.id DESC
+    ) AS rn
+FROM `tbl_submission` s;
+
+CREATE TEMPORARY TABLE `tmp_submission_delete_ids` AS
+SELECT id
+FROM `tmp_submission_ranked`
+WHERE rn > 1;
+
+DELETE aa
+FROM `tbl_application_answer` aa
+         JOIN `tmp_submission_delete_ids` d ON aa.submission_id = d.id;
+
+DELETE s
+FROM `tbl_submission` s
+         JOIN `tmp_submission_delete_ids` d ON s.id = d.id;
+
+DROP TEMPORARY TABLE IF EXISTS `tmp_submission_delete_ids`;
+DROP TEMPORARY TABLE IF EXISTS `tmp_submission_ranked`;
+
 ALTER TABLE `tbl_submission`
     ADD CONSTRAINT `unique_idx_submission_account_form`
         UNIQUE (`account_id`, `application_form_id`);

--- a/src/main/resources/db/migration/V4__add_submission_unique_constraint_per_form.sql
+++ b/src/main/resources/db/migration/V4__add_submission_unique_constraint_per_form.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `tbl_submission`
+    ADD CONSTRAINT `unique_idx_submission_account_form`
+        UNIQUE (`account_id`, `application_form_id`);


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #284

## 📝작업 내용

> 같은 동아리 내에서도 공고(`applicationForm`)가 다르면 지원 가능하도록 중복 검사 기준을 변경했습니다.

- 지원서 생성 중복 검사 기준 변경
  - 기존: `userId + clubId`
  - 변경: `userId + applicationFormId`
- 중복 예외 메시지를 정책에 맞게 수정
  - `해당 동아리의 지원서가 이미 존재합니다.`
  - -> `해당 공고의 지원서가 이미 존재합니다.`
- 다중 지원 이력 환경에서 동아리 선택 로직 보정
  - `DecideClubService`가 `ACCEPTED` 상태의 최신 지원서를 기준으로 조회하도록 변경
- 사용하지 않는 레거시 조회 메서드 정리
  - `findByUserIdAndClubId` 제거
- DB 레벨 제약 추가(Flyway)
  - `tbl_submission (account_id, application_form_id)` 유니크 제약 추가
  - 파일: `V4__add_submission_unique_constraint_per_form.sql`

### 스크린샷 (선택)

- 없음

## 💬리뷰 요구사항(선택)

> 아래 두 가지를 중점으로 확인 부탁드립니다.

- `DecideClubService`에서 `ACCEPTED` 최신 건 조회 방식이 현재 알림/선택 플로우와 충돌 없는지
- Flyway V4 유니크 제약이 운영 데이터에 안전하게 적용 가능한지(중복 데이터 사전 점검 필요 여부)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 중복 지원 검출 범위를 공고(지원서) 기준으로 정확히 검사하도록 개선했습니다.
  * 지원 확정 처리 시 최신의 승인된 지원서를 정확히 선택하도록 수정했습니다.

* **Documentation**
  * 중복 지원 관련 오류 메시지를 "공고" 기준 문구로 업데이트했습니다.

* **Chores**
  * 동일 공고당 중복 지원을 막는 DB 제약을 추가하고, 제약 위반을 사용자 친화적인 예외로 처리하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->