### PR TITLE
feat(#286): 발표기간 경과 시 합불 결과 즉시 발송 처리

### DIFF
--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/PassClubService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/PassClubService.java
@@ -1,6 +1,7 @@
 package team.jeonghokim.daedongyeojido.domain.club.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,12 +11,15 @@ import team.jeonghokim.daedongyeojido.domain.club.exception.AlreadyJoinClubExcep
 import team.jeonghokim.daedongyeojido.domain.club.exception.ClubAccessDeniedException;
 import team.jeonghokim.daedongyeojido.domain.club.presentation.dto.request.PassClubRequest;
 import team.jeonghokim.daedongyeojido.domain.resultduration.domain.ResultDuration;
+import team.jeonghokim.daedongyeojido.domain.resultduration.domain.enums.Status;
 import team.jeonghokim.daedongyeojido.domain.resultduration.domain.repository.ResultDurationRepository;
 import team.jeonghokim.daedongyeojido.domain.resultduration.exception.ResultDurationNotFoundException;
 import team.jeonghokim.daedongyeojido.domain.schedule.domain.repository.ScheduleRepository;
 import team.jeonghokim.daedongyeojido.domain.schedule.exception.InterviewNotScheduledException;
 import team.jeonghokim.daedongyeojido.domain.smshistory.domain.enums.SmsReferenceType;
 import team.jeonghokim.daedongyeojido.domain.smshistory.service.SmsHistoryService;
+import team.jeonghokim.daedongyeojido.infrastructure.event.alarm.event.LargeScaleAlarmEvent;
+import team.jeonghokim.daedongyeojido.infrastructure.event.sms.event.LargeScaleSmsEvent;
 import team.jeonghokim.daedongyeojido.infrastructure.scheduler.payload.SchedulerAlarmPayload;
 import team.jeonghokim.daedongyeojido.infrastructure.scheduler.payload.SchedulerSmsPayload;
 import team.jeonghokim.daedongyeojido.domain.submission.domain.Submission;
@@ -24,6 +28,7 @@ import team.jeonghokim.daedongyeojido.domain.user.domain.User;
 import team.jeonghokim.daedongyeojido.domain.user.facade.UserFacade;
 import team.jeonghokim.daedongyeojido.infrastructure.sms.type.Message;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import static team.jeonghokim.daedongyeojido.infrastructure.redis.key.RedisKey.RESULT_DURATION_ALARM_ZSET;
@@ -39,6 +44,7 @@ public class PassClubService {
     private final ScheduleRepository scheduleRepository;
     private final RedisTemplate<String, SchedulerSmsPayload> smsRedisTemplate;
     private final RedisTemplate<String, SchedulerAlarmPayload> alarmRedisTemplate;
+    private final ApplicationEventPublisher eventPublisher;
     private final SmsHistoryService smsHistoryService;
 
     public static final String SEOUL_TIME_ZONE = "Asia/Seoul";
@@ -53,15 +59,20 @@ public class PassClubService {
 
         validate(user, submission);
 
-        ResultDuration resultDuration = resultDurationRepository.findPendingResultDuration()
-                .orElseThrow(() -> ResultDurationNotFoundException.EXCEPTION);
+        ResultDurationDispatchContext resultDurationDispatchContext = resolveResultDurationDispatchContext();
+        ResultDuration resultDuration = resultDurationDispatchContext.resultDuration();
 
         submission.applyClubPassResult(request.isPassed());
         submission.markInterviewCompleted();
 
-        saveSMS(submission, request.isPassed(), resultDuration);
+        if (resultDurationDispatchContext.dispatchImmediately()) {
+            submission.applyUserPassResult(request.isPassed());
+            dispatchResultImmediately(submission, request.isPassed(), resultDuration);
+            return;
+        }
 
-        saveAlarm(submission, request.isPassed(), resultDuration);
+        saveQueuedSMS(submission, request.isPassed(), resultDuration);
+        saveQueuedAlarm(submission, request.isPassed(), resultDuration);
     }
 
     private void validate(User user, Submission submission) {
@@ -79,7 +90,7 @@ public class PassClubService {
         }
     }
 
-    private void saveSMS(Submission submission, boolean isPassed, ResultDuration resultDuration) {
+    private void saveQueuedSMS(Submission submission, boolean isPassed, ResultDuration resultDuration) {
 
         long score = resultDuration.getResultDurationTime()
                 .atZone(ZoneId.of(SEOUL_TIME_ZONE))
@@ -106,7 +117,7 @@ public class PassClubService {
                 .add(RESULT_DURATION_SMS_ZSET, payload, score);
     }
 
-    private void saveAlarm(Submission submission, boolean isPassed, ResultDuration resultDuration) {
+    private void saveQueuedAlarm(Submission submission, boolean isPassed, ResultDuration resultDuration) {
 
         long score = resultDuration.getResultDurationTime()
                 .atZone(ZoneId.of(SEOUL_TIME_ZONE))
@@ -122,5 +133,95 @@ public class PassClubService {
 
         alarmRedisTemplate.opsForZSet()
                 .add(RESULT_DURATION_ALARM_ZSET, payload, score);
+    }
+
+    private void dispatchResultImmediately(Submission submission, boolean isPassed, ResultDuration resultDuration) {
+        SchedulerSmsPayload smsPayload = dispatchSmsImmediately(submission, isPassed, resultDuration);
+        dispatchAlarmImmediately(submission, isPassed, resultDuration, smsPayload);
+    }
+
+    private SchedulerSmsPayload dispatchSmsImmediately(Submission submission, boolean isPassed, ResultDuration resultDuration) {
+        Long smsHistoryId = smsHistoryService.createImmediate(
+                SmsReferenceType.CLUB_RESULT,
+                submission.getId(),
+                submission.getUser(),
+                isPassed ? Message.CLUB_FINAL_ACCEPTED : Message.CLUB_FINAL_REJECTED,
+                submission.getApplicationForm().getClub().getClubName()
+        );
+
+        SchedulerSmsPayload payload = SchedulerSmsPayload.builder()
+                .smsHistoryId(smsHistoryId)
+                .submissionId(submission.getId())
+                .phoneNumber(submission.getUser().getPhoneNumber())
+                .isPassed(isPassed)
+                .clubName(submission.getApplicationForm().getClub().getClubName())
+                .build();
+
+        eventPublisher.publishEvent(
+                LargeScaleSmsEvent.builder()
+                        .smsHistoryId(smsHistoryId)
+                        .phoneNumber(payload.phoneNumber())
+                        .message(isPassed ? Message.CLUB_FINAL_ACCEPTED : Message.CLUB_FINAL_REJECTED)
+                        .clubName(payload.clubName())
+                        .payload(payload)
+                        .resultDuration(resultDuration)
+                        .build()
+        );
+
+        return payload;
+    }
+
+    private void dispatchAlarmImmediately(
+            Submission submission,
+            boolean isPassed,
+            ResultDuration resultDuration,
+            SchedulerSmsPayload smsPayload
+    ) {
+        AlarmType alarmType = isPassed ? AlarmType.CLUB_FINAL_ACCEPTED : AlarmType.CLUB_FINAL_REJECTED;
+
+        SchedulerAlarmPayload payload = SchedulerAlarmPayload.builder()
+                .alarmType(alarmType)
+                .clubId(submission.getApplicationForm().getClub().getId())
+                .submissionId(submission.getId())
+                .userId(submission.getUser().getId())
+                .isPassed(isPassed)
+                .build();
+
+        eventPublisher.publishEvent(
+                LargeScaleAlarmEvent.builder()
+                        .alarmType(alarmType)
+                        .category(alarmType.getCategory())
+                        .title(alarmType.formatTitle(smsPayload.clubName()))
+                        .content(alarmType.formatContent(smsPayload.clubName()))
+                        .clubId(payload.clubId())
+                        .userId(payload.userId())
+                        .payload(payload)
+                        .resultDuration(resultDuration)
+                        .isPassed(isPassed)
+                        .build()
+        );
+    }
+
+    private ResultDurationDispatchContext resolveResultDurationDispatchContext() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of(SEOUL_TIME_ZONE));
+
+        return resultDurationRepository.findPendingResultDuration()
+                .map(resultDuration -> new ResultDurationDispatchContext(
+                        resultDuration,
+                        !resultDuration.getResultDurationTime().isAfter(now)
+                ))
+                .or(() -> resultDurationRepository.findTopByOrderByIdDesc()
+                        .map(resultDuration -> new ResultDurationDispatchContext(
+                                resultDuration,
+                                resultDuration.getSmsStatus() != Status.PENDING
+                                        && resultDuration.getAlarmStatus() != Status.PENDING
+                        )))
+                .orElseThrow(() -> ResultDurationNotFoundException.EXCEPTION);
+    }
+
+    private record ResultDurationDispatchContext(
+            ResultDuration resultDuration,
+            boolean dispatchImmediately
+    ) {
     }
 }

--- a/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/PassClubService.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/domain/club/service/PassClubService.java
@@ -182,7 +182,8 @@ public class PassClubService {
         SchedulerAlarmPayload payload = SchedulerAlarmPayload.builder()
                 .alarmType(alarmType)
                 .clubId(submission.getApplicationForm().getClub().getId())
-                .submissionId(submission.getId())
+                // 즉시 경로는 서비스에서 상태를 먼저 반영하므로 리스너 중복 반영을 막기 위해 submissionId를 비워둔다.
+                .submissionId(null)
                 .userId(submission.getUser().getId())
                 .isPassed(isPassed)
                 .build();

--- a/src/main/java/team/jeonghokim/daedongyeojido/infrastructure/event/alarm/listener/LargeScaleAlarmEventListener.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/infrastructure/event/alarm/listener/LargeScaleAlarmEventListener.java
@@ -13,6 +13,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import team.jeonghokim.daedongyeojido.domain.admin.service.DecideResultDurationService;
 import team.jeonghokim.daedongyeojido.domain.alarm.domain.UserAlarm;
 import team.jeonghokim.daedongyeojido.domain.alarm.domain.repository.UserAlarmRepository;
@@ -51,7 +53,7 @@ public class LargeScaleAlarmEventListener {
             maxAttempts = 5,
             backoff = @Backoff(delay = 500, multiplier = 2)
     )
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleLargeScaleAlarmEvent(LargeScaleAlarmEvent event) {
 

--- a/src/main/java/team/jeonghokim/daedongyeojido/infrastructure/event/sms/listener/LargeScaleSmsEventListener.java
+++ b/src/main/java/team/jeonghokim/daedongyeojido/infrastructure/event/sms/listener/LargeScaleSmsEventListener.java
@@ -13,6 +13,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import team.jeonghokim.daedongyeojido.domain.admin.service.DecideResultDurationService;
 import team.jeonghokim.daedongyeojido.domain.resultduration.domain.repository.ResultDurationRepository;
 import team.jeonghokim.daedongyeojido.domain.smshistory.service.SmsHistoryService;
@@ -52,7 +54,7 @@ public class LargeScaleSmsEventListener {
             maxAttempts = 5,
             backoff = @Backoff(delay = 500, multiplier = 2)
     )
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleLargeScaleSmsEvent(LargeScaleSmsEvent event) {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #286

## 📝작업 내용

> 발표기간(`result_duration`) 상태에 따라 합격/불합격 처리 경로를 분기하도록 수정했습니다.

- `PassClubService`에 발표기간 기준 분기 로직 추가
- 발표기간 **이전**(`resultDurationTime > now`)인 경우:
  - 기존 로직 유지 (Redis ZSET 적재 + queued sms_history)
- 발표기간 **도달/경과**(`resultDurationTime <= now`)인 경우:
  - ZSET 적재 없이 즉시 이벤트 발행(SMS/Alarm)
  - 지원자 `userApplicationStatus` 즉시 반영
- `PENDING` 발표기간이 없는 경우:
  - 최신 발표기간을 기준으로 즉시 처리 경로 사용
- 컴파일 검증 완료 (`./gradlew compileJava`)

### 스크린샷 (선택)

- 없음

## 💬리뷰 요구사항(선택)

- 발표기간 경계 시점(`== now`)을 즉시 발송으로 처리한 정책이 도메인 의도와 일치하는지 확인 부탁드립니다.
- `PENDING`이 없는 경우 최신 발표기간으로 즉시 처리하는 fallback이 운영 흐름에 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 합격 결과에 따라 SMS와 알림을 즉시 발송하거나 예약 발송하도록 알림 발송 로직이 개선되었습니다.
* **버그 수정 / 안정성 개선**
  * 알림 처리 시 트랜잭션 커밋 후에만 실제 전송 처리가 실행되도록 변경되어, 실패 시 중복 또는 누락 가능성이 감소했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->